### PR TITLE
fix(media): let a station be reached, and say which camera a record is about

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.6",
-        "@mega-yfue/eufy-sdk": "0.1.0",
+        "@mega-yfue/eufy-sdk": "0.1.2",
         "ffmpeg-for-homebridge": "2.2.2"
       },
       "devDependencies": {
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@mega-yfue/eufy-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mega-yfue/eufy-sdk/-/eufy-sdk-0.1.0.tgz",
-      "integrity": "sha512-WJsl56X9z7ZHcpD3RWHvqeOxd7zPfT+pfUDn7UcQWPSH6nq4xO0jM9pnBELg4YCsVMQAckmv/PPJ4pma2g5ymg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@mega-yfue/eufy-sdk/-/eufy-sdk-0.1.2.tgz",
+      "integrity": "sha512-6a1T266QoimvRPuGH9domklaSbP7pXXzBO9YezqXKrHdi4w31IQvxZtEAAArZLHpvdZ+ntlsc39GtJYcDN4gDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "jpeg-js": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.6",
-    "@mega-yfue/eufy-sdk": "0.1.0",
+    "@mega-yfue/eufy-sdk": "0.1.2",
     "ffmpeg-for-homebridge": "2.2.2"
   },
   "devDependencies": {

--- a/scripts/decrypt-diagnostics.mjs
+++ b/scripts/decrypt-diagnostics.mjs
@@ -38,6 +38,7 @@ const ENVELOPE_FIELDS = new Set([
   'ciphertext',
 ]);
 const EVIDENCE_FILES = new Map([
+  ['reporter-statement', ['reporter-statement.json', 'application/json', 'diagnostic']],
   ['environment', ['environment.json', 'application/json', 'operational']],
   ['reproduction-markers', ['reproduction-markers.jsonl', 'application/x-ndjson', 'operational']],
   ['plugin-log', ['plugin-log.jsonl', 'application/x-ndjson', 'diagnostic']],

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -61,10 +61,15 @@ export function unconfirmedWriteCondition(property: string): HomeKitCondition | 
     : { code: 'camera-control-operation-failed', ...named, active: true, reason: 'not-confirmed' };
 }
 
-export type HomeKitEventTrace =
-  | { adapter: string; event: string; observation: string; announcedBy?: string }
+/**
+ * One redacted fact about a HomeKit adapter, and the accessory it belongs to.
+ *
+ * `serial` is an identity and is never retained. {@link reportHomeKitEvent} resolves it to a support-case alias,
+ * which is what names one camera of a household in a record that names no device.
+ */
+export type HomeKitEventTrace = { adapter: string; serial?: string } & (
+  | { event: string; observation: string; announcedBy?: string }
   | {
-      adapter: string;
       event: 'live-video-selected';
       operation: 'start' | 'reconfigure';
       profile: 'baseline' | 'main' | 'high';
@@ -76,13 +81,17 @@ export type HomeKitEventTrace =
       addressVersion: 'ipv4' | 'ipv6';
     }
   | {
-      adapter: string;
       event: 'live-session-failed';
       outcome: 'failed';
       reason: string;
       stage: 'sdk-source-acquisition' | 'first-source-keyframe' | 'first-adapted-output' | 'controller-rtcp';
     }
-  | { adapter: string; event: 'live-session-released' }
+  /**
+   * A session gave its source back, stating whether it was asked to or ended itself.
+   *
+   * A controller stops showing a picture either way, so this record is the only place the two differ.
+   */
+  | { event: 'live-session-released'; release: string }
   /**
    * The first adapted output reached the negotiated destination.
    *
@@ -90,7 +99,7 @@ export type HomeKitEventTrace =
    * nothing from one whose output a controller did not display. Carries the fact alone: a session identity,
    * a port and a key all travel in the same neighbourhood.
    */
-  | { adapter: string; event: 'live-session-streaming' }
+  | { event: 'live-session-streaming' }
   /**
    * A started request reached neither a streaming outcome nor a failure.
    *
@@ -98,14 +107,18 @@ export type HomeKitEventTrace =
    * failure this log has no record of, and nobody can diagnose what was never written down. Carries how long
    * was waited and nothing else: the path that dropped the request left nothing else to carry.
    */
-  | { adapter: string; event: 'live-request-unaccounted'; afterMs: number }
+  | { event: 'live-request-unaccounted'; afterMs: number }
   /**
    * A stream request refused before it reached the source.
    *
    * Answered to a controller instantly, and badged by it instantly. Carries the bounded reason alone, which is
    * enough to tell a momentary switch collision from a camera that is genuinely off or a host genuinely full.
    */
-  | { adapter: string; event: 'live-request-refused'; reason: string };
+  | { event: 'live-request-refused'; reason: string }
+);
+
+/** Why a live session gave its source back: a stop from outside it, or the session ending itself. */
+const LIVE_SESSION_RELEASES = ['requested', 'failed'] as const;
 
 /** The bounded reasons a stream request is refused before it reaches the source. */
 const REFUSAL_REASONS = new Set(['disabled', 'at-capacity', 'cancelled', 'prepare-failed']);
@@ -122,6 +135,22 @@ const HOMEKIT_LIVE_REQUEST_EVENTS = new Set([
   'live-session-released',
   'live-session-streaming',
 ]);
+
+/**
+ * The error identities an SDK record may name, which is all a record carries of one.
+ *
+ * A message is never among them, so an identity absent here is recorded as `Error` and reads as any other
+ * failure. A station refusing a second camera is one of these identities, because a base serving another of its
+ * cameras is working correctly and must not read as a fault.
+ */
+const SDK_ERROR_TYPES = ['Error', 'RangeError', 'SessionExpiredError', 'StationBusyError', 'TypeError'] as const;
+
+/**
+ * The retained fields that stand for a device rather than describing one, which is the privacy class a manifest
+ * declares for them. Each holds a per-case alias: stable within one archive, and resolvable to a device only by
+ * the owner whose console paired it with a name.
+ */
+const PSEUDONYMOUS_FIELDS = new Set(['accessory', 'accessoryAliases']);
 
 const MAX_SDK_DETAILS = 16;
 const MAX_LOG_RECORD_BYTES = 64 * 1024;
@@ -253,6 +282,16 @@ export type DiagnosticsReproductionMode = 'now' | 'intermittent';
  * answer, so the question is asked once here rather than again in the issue.
  */
 export type AffectedDevices = 'all' | readonly string[];
+
+/**
+ * The reporter's answer as a support archive carries it: every device, or how many they named.
+ *
+ * The serials themselves stay on the host. They identify one household's hardware, and no evidence class in an
+ * archive carries a device identity.
+ */
+function countedAffectedDevices(affected: AffectedDevices): 'all' | number {
+  return affected === 'all' ? 'all' : new Set(affected).size;
+}
 
 /** The bounded UI events a support session may record, and the only vocabulary the sink accepts. */
 const DIAGNOSTICS_UI_EVENTS = [
@@ -878,15 +917,15 @@ export class GuidedDiagnostics {
               evidence: 'reporter-statement' as const,
               privacyClass: 'diagnostic' as const,
               contentType: 'application/json' as const,
-              content: `${JSON.stringify({ version: 1, affectedDevices: session.affectedDevices })}\n`,
+              content: `${JSON.stringify({ version: 2, affectedDevices: countedAffectedDevices(session.affectedDevices) })}\n`,
               /**
-               * What the reporter answered, not what the plugin observed. A serial identifies one household's
-               * hardware, so the record is classified above the environment it sits beside and stays inside
-               * the archive.
+               * What the reporter answered, not what the plugin observed. A serial is a device identity and no
+               * evidence class carries one, so the answer travels as its scope: every device, or how many were
+               * named. Which ones is the reporter's to say in their own words.
                */
               fields: [
                 { field: 'version', privacyClass: 'operational' as const },
-                { field: 'affectedDevices', privacyClass: 'pseudonymous' as const },
+                { field: 'affectedDevices', privacyClass: 'operational' as const },
               ],
             },
           ]),
@@ -954,8 +993,11 @@ export class GuidedDiagnostics {
         ...(carried.retainedFrom === undefined ? {} : { retainedFrom: carried.retainedFrom }),
         fields: [...new Set(carried.records.flatMap((record) => Object.keys(record)))].sort().map((field) => ({
           field,
-          privacyClass:
-            field === 'accessoryAliases' ? 'pseudonymous' : field === 'timestamp' ? 'operational' : 'diagnostic',
+          privacyClass: PSEUDONYMOUS_FIELDS.has(field)
+            ? 'pseudonymous'
+            : field === 'timestamp'
+              ? 'operational'
+              : 'diagnostic',
         })),
       });
     }
@@ -1576,6 +1618,19 @@ function opaquePullHandle(value: unknown): string | undefined {
 }
 
 /**
+ * One support-case accessory alias, or nothing where the value is not one.
+ *
+ * Matched against the shape an alias has rather than against what a serial looks like, on the same rule as
+ * {@link opaquePullHandle}: a record carries an alias or it carries no accessory at all.
+ */
+function opaqueAccessoryAlias(value: unknown): string | undefined {
+  return typeof value === 'string' &&
+    /^accessory-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value)
+    ? value
+    : undefined;
+}
+
+/**
  * Adapts SDK protocol detail to bounded debug output without preserving supplied values.
  *
  * The SDK runs FFmpeg of its own for snapshot decoding and WebRTC containers and forwards that process's
@@ -1614,9 +1669,7 @@ export function createSdkLogger(target: Partial<PlatformLogger> | undefined): Lo
     const subsystem = SDK_SUBSYSTEMS.has(requestedSubsystem ?? '') ? requestedSubsystem : (aliasedSubsystem ?? 'sdk');
     const details = args.slice(0, MAX_SDK_DETAILS).map((value) => {
       if (value instanceof Error) {
-        const errorType = ['Error', 'RangeError', 'SessionExpiredError', 'TypeError'].includes(value.name)
-          ? value.name
-          : 'Error';
+        const errorType = (SDK_ERROR_TYPES as readonly string[]).includes(value.name) ? value.name : 'Error';
         return { errorType };
       }
       if (typeof value === 'string') {
@@ -2043,12 +2096,7 @@ function sanitizeStructuredEvent(message: string): Record<string, unknown> | und
     for (const detail of Array.isArray(value.details) ? value.details.slice(0, MAX_SDK_DETAILS) : []) {
       if (!detail || typeof detail !== 'object' || Array.isArray(detail)) continue;
       const candidate = detail as Record<string, unknown>;
-      const errorType = allowlistedLabel(candidate.errorType, [
-        'Error',
-        'RangeError',
-        'SessionExpiredError',
-        'TypeError',
-      ]);
+      const errorType = allowlistedLabel(candidate.errorType, SDK_ERROR_TYPES);
       if (errorType) {
         details.push({ errorType });
         continue;
@@ -2117,6 +2165,7 @@ function sanitizeStructuredEvent(message: string): Record<string, unknown> | und
     ) {
       return undefined;
     }
+    const alias = opaqueAccessoryAlias(value.accessory);
     return {
       scope: 'homekit',
       level: 'debug',
@@ -2126,6 +2175,7 @@ function sanitizeStructuredEvent(message: string): Record<string, unknown> | und
       ...(typeof value.announcedBy === 'string' && HOMEKIT_ANNOUNCEMENTS.has(value.announcedBy)
         ? { announcedBy: value.announcedBy }
         : {}),
+      ...(alias === undefined ? {} : { accessory: alias }),
     };
   }
 
@@ -2269,17 +2319,29 @@ export function reportInvalidSnapshotCache(
   target.debug?.(JSON.stringify({ scope: 'media-notice', level, code, messageKey }));
 }
 
-/** Emits one allowlisted HomeKit event trace only when host debug output is available. */
-export function reportHomeKitEvent(target: Pick<PlatformLogger, 'debug'>, trace: HomeKitEventTrace): void {
+/**
+ * Emits one allowlisted HomeKit event trace only when host debug output is available.
+ *
+ * `aliasFor` resolves the trace's device identity to the support-case alias the conditions about that accessory
+ * already carry. The identity itself never reaches the record: an unresolved one is recorded as no accessory.
+ */
+export function reportHomeKitEvent(
+  target: Pick<PlatformLogger, 'debug'>,
+  trace: HomeKitEventTrace,
+  aliasFor?: (serial: string) => string | undefined,
+): void {
+  const alias = typeof trace.serial === 'string' ? aliasFor?.(trace.serial) : undefined;
+  const offered = { ...(trace as unknown as Record<string, unknown>), accessory: alias };
+  const accessory = alias === undefined ? {} : { accessory: alias };
   if (trace.event === 'live-video-selected') {
-    const selection = sanitizeLiveVideoSelection(trace as unknown as Record<string, unknown>);
+    const selection = sanitizeLiveVideoSelection(offered);
     if (target.debug && selection) {
       target.debug(JSON.stringify({ scope: 'homekit', level: 'debug', ...selection }));
     }
     return;
   }
   if (HOMEKIT_LIVE_REQUEST_EVENTS.has(trace.event)) {
-    const lifecycle = sanitizeLiveSessionTrace(trace as unknown as Record<string, unknown>);
+    const lifecycle = sanitizeLiveSessionTrace(offered);
     if (target.debug && lifecycle) {
       target.debug(JSON.stringify({ scope: 'homekit', level: 'debug', ...lifecycle }));
     }
@@ -2304,6 +2366,7 @@ export function reportHomeKitEvent(target: Pick<PlatformLogger, 'debug'>, trace:
       ...(typeof trace.announcedBy === 'string' && HOMEKIT_ANNOUNCEMENTS.has(trace.announcedBy)
         ? { announcedBy: trace.announcedBy }
         : {}),
+      ...accessory,
     }),
   );
 }
@@ -2457,17 +2520,23 @@ function sanitizeLiveSessionTrace(value: Record<string, unknown>): Record<string
   if (value.adapter !== 'camera.streaming') {
     return undefined;
   }
-  if (value.event === 'live-session-released' || value.event === 'live-session-streaming') {
-    return { adapter: value.adapter, event: value.event };
+  const alias = opaqueAccessoryAlias(value.accessory);
+  const accessory = alias === undefined ? {} : { accessory: alias };
+  if (value.event === 'live-session-released') {
+    const release = allowlistedLabel(value.release, LIVE_SESSION_RELEASES);
+    return release ? { adapter: value.adapter, event: value.event, release, ...accessory } : undefined;
+  }
+  if (value.event === 'live-session-streaming') {
+    return { adapter: value.adapter, event: value.event, ...accessory };
   }
   if (value.event === 'live-request-refused') {
     return typeof value.reason === 'string' && REFUSAL_REASONS.has(value.reason)
-      ? { adapter: value.adapter, event: value.event, reason: value.reason }
+      ? { adapter: value.adapter, event: value.event, reason: value.reason, ...accessory }
       : undefined;
   }
   if (value.event === 'live-request-unaccounted') {
     return typeof value.afterMs === 'number' && Number.isFinite(value.afterMs)
-      ? { adapter: value.adapter, event: value.event, afterMs: Math.round(value.afterMs) }
+      ? { adapter: value.adapter, event: value.event, afterMs: Math.round(value.afterMs), ...accessory }
       : undefined;
   }
   if (
@@ -2486,6 +2555,7 @@ function sanitizeLiveSessionTrace(value: Record<string, unknown>): Record<string
     outcome: value.outcome,
     reason: value.reason,
     stage: value.stage,
+    ...accessory,
   };
 }
 
@@ -2515,6 +2585,7 @@ function sanitizeLiveVideoSelection(value: Record<string, unknown>): Record<stri
   ) {
     return undefined;
   }
+  const alias = opaqueAccessoryAlias(value.accessory);
   return {
     adapter: 'camera.streaming',
     event: 'live-video-selected',
@@ -2526,6 +2597,7 @@ function sanitizeLiveVideoSelection(value: Record<string, unknown>): Record<stri
     fps,
     mtu,
     addressVersion,
+    ...(alias === undefined ? {} : { accessory: alias }),
   };
 }
 
@@ -2594,7 +2666,7 @@ export class DiagnosticConditions {
     }
     const uniqueDeviceIds = condition.active ? [...new Set(affectedDeviceIds)].sort() : [];
     const accessoryAliases = uniqueDeviceIds
-      .map((identity) => this.accessoryAlias(identity))
+      .map((identity) => this.aliasFor(identity))
       .filter((alias): alias is string => alias !== undefined)
       .sort();
     this.write(
@@ -2622,7 +2694,13 @@ export class DiagnosticConditions {
     );
   }
 
-  private accessoryAlias(identity: string): string | undefined {
+  /**
+   * The support-case alias for one device identity, minted on first use.
+   *
+   * The one place an alias is decided, so every record about a device — a condition, a media trace — carries
+   * the same one, and the owner's console line is what resolves it to a name.
+   */
+  aliasFor(identity: string): string | undefined {
     let alias = this.aliases.get(identity);
     if (!alias && this.aliases.size < MAX_ACCESSORY_ALIASES) {
       alias = `accessory-${randomUUID()}`;

--- a/src/homekit/adapter.ts
+++ b/src/homekit/adapter.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   LiveMediaAdapter,
   LiveSessionOutcome,
+  LiveSessionRelease,
   MediaSessionBudget,
   StationLiveSessionRegistry,
   NegotiatedLiveVideo,
@@ -85,7 +86,13 @@ export type AdapterLiveVideoTrace = Pick<
 /** An identity-free live-session failure or release milestone. */
 export type AdapterLiveSessionTrace =
   | (Extract<LiveSessionOutcome, { outcome: 'failed' }> & { event: 'live-session-failed' })
-  | { event: 'live-session-released' }
+  /**
+   * A session gave its source back, and whether it was asked to or ended itself.
+   *
+   * Both look identical on a controller, which simply stops showing a picture, so the record is the only place
+   * the difference exists.
+   */
+  | { event: 'live-session-released'; release: LiveSessionRelease }
   /** The first adapted output reached the negotiated destination, which is when a picture can appear. */
   | { event: 'live-session-streaming' }
   /**

--- a/src/homekit/adapters/camera-streaming.ts
+++ b/src/homekit/adapters/camera-streaming.ts
@@ -28,6 +28,7 @@ import type {
   LiveMediaAdapter,
   LiveMediaSource,
   LiveSessionOutcome,
+  LiveSessionRelease,
   MediaSessionBudget,
   StationLiveSessionRegistry,
   MediaSessionClaim,
@@ -356,7 +357,7 @@ function attachCameraStreaming(context: AdapterAttachmentContext): AttachedAdapt
     enablement,
     availability: availabilityObservation(context.device.sn, context.availability),
     reportSession: liveSessionReporter(context, reportAdmission),
-    reportRelease: () => context.trace?.({ event: 'live-session-released' }),
+    reportRelease: (release) => context.trace?.({ event: 'live-session-released', release }),
     reportTalkback: talkbackReporter(context),
     reportAdmission,
     reportCapacity,
@@ -1106,7 +1107,7 @@ interface LiveCameraBinding {
   readonly enablement: () => boolean | undefined;
   readonly availability: () => 'available' | 'unavailable' | undefined;
   readonly reportSession: (outcome: LiveSessionOutcome, switchedOff?: boolean) => void;
-  readonly reportRelease: () => void;
+  readonly reportRelease: (release: LiveSessionRelease) => void;
   readonly reportTalkback: (outcome: TalkbackOutcome) => void;
   readonly reportAdmission: (refusal?: LiveAdmissionRefusal) => void;
   readonly reportCapacity: (refusal?: MediaCapacityRefusal) => void;

--- a/src/homekit/reconciler.ts
+++ b/src/homekit/reconciler.ts
@@ -58,8 +58,13 @@ export interface RepresentationDiagnostic {
 export type HomeKitDiagnostic = RepresentationDiagnostic | AdapterDiagnostic;
 export type HomeKitDiagnosticSink = (diagnostic: HomeKitDiagnostic, affectedDeviceIds: readonly string[]) => void;
 
-/** Redacted debug evidence that an SDK event reached one self-hosted adapter. */
-export type HomeKitEventReport = { adapter: string } & AdapterTrace;
+/**
+ * Redacted debug evidence that an SDK event reached one self-hosted adapter, and the device it is about.
+ *
+ * One adapter serves every camera of a household, so the adapter alone does not identify what a report concerns.
+ * `serial` is an identity: the sink resolves it to a support-case alias and retains that.
+ */
+export type HomeKitEventReport = { adapter: string; serial: string } & AdapterTrace;
 
 export type HomeKitEventReportSink = (trace: HomeKitEventReport) => void;
 
@@ -207,7 +212,7 @@ export class HomeKitReconciler {
           availability: () => this.source.currentAvailability?.(serial),
           diagnose: (diagnostic) => this.setAdapterDiagnostic(serial, key, diagnostic),
           observed: (code) => this.clearAdapterDiagnostics(serial, code, key),
-          trace: (trace) => this.trace?.({ adapter: key, ...trace }),
+          trace: (trace) => this.trace?.({ adapter: key, serial, ...trace }),
           persist: () => this.store.update([accessory]),
         });
         if (handle) {
@@ -300,7 +305,7 @@ export class HomeKitReconciler {
     for (const [adapter, handle] of this.attachedAdapters.get(event.deviceSn) ?? []) {
       const result = handle.event?.(event);
       if (result) {
-        this.trace?.({ adapter, ...result });
+        this.trace?.({ adapter, serial: event.deviceSn, ...result });
       }
     }
   }

--- a/src/media/contracts.ts
+++ b/src/media/contracts.ts
@@ -231,6 +231,16 @@ export interface StationLiveSessionRegistry {
   hold(stationSn: string, camera: string, claim: StationLiveClaim, abandon?: () => void): () => void;
 }
 
+/**
+ * Why a live session gave its source back.
+ *
+ * `requested` is a stop from outside the session: a controller closing the view, a switch to another camera, a
+ * host giving room back. `failed` is the session ending itself, and the failure that decided it carries its own
+ * reason and stage. One is a session that served for as long as it was wanted and the other is a fault, so a
+ * release states which.
+ */
+export type LiveSessionRelease = 'requested' | 'failed';
+
 export interface LiveMediaTransport {
   readonly addressVersion: 'ipv4' | 'ipv6';
   readonly targetAddress: string;
@@ -238,7 +248,7 @@ export interface LiveMediaTransport {
   readonly audio?: LiveMediaTarget;
   readonly onVideoFailure?: () => void;
   readonly onSessionOutcome?: (outcome: LiveSessionOutcome) => void;
-  readonly onSessionReleased?: () => void;
+  readonly onSessionReleased?: (release: LiveSessionRelease) => void;
   readonly onTalkbackOutcome?: (outcome: TalkbackOutcome) => void;
 }
 

--- a/src/media/live-stream.ts
+++ b/src/media/live-stream.ts
@@ -1,5 +1,5 @@
 import type { LiveAudioFrame, LiveStreamConsumer, LiveVideoConfig, LiveVideoFrame, TalkbackHandle } from '@mega-yfue/eufy-sdk';
-import { LiveStreamStartError } from '@mega-yfue/eufy-sdk';
+import { LiveStreamStartError, StationBusyError } from '@mega-yfue/eufy-sdk';
 import { createSocket } from 'node:dgram';
 import { execFile, spawn } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -56,7 +56,18 @@ function canCode(running: LiveVideoConfig, announced: LiveVideoConfig): boolean 
 const MAX_SOURCE_INPUT_REPLACEMENTS = 3;
 
 const INITIAL_RTCP_GRACE_MS = 15_000;
-const SOURCE_ACQUISITION_DEADLINE_MS = 10_000;
+/**
+ * The longest a session waits for the SDK to hand over a source, after which it cancels the acquisition.
+ *
+ * Reaching a station is inside this wait: an unconnected station is reconnected within it, and a HomeBase
+ * resolves its session before it can start one. The bound is therefore above what reaching a station costs and
+ * below both {@link SOURCE_START_BACKSTOP_MS} and the window a started request is owed an outcome within, so
+ * the acquisition is what this expiry reports.
+ *
+ * Expiry cancels the acquisition. A station serves one media channel, and an uncancelled acquisition holds it
+ * until the SDK's own wait elapses, which refuses every camera behind that station meanwhile.
+ */
+const SOURCE_ACQUISITION_DEADLINE_MS = 25_000;
 const RETURN_AUDIO_BIND_GRACE_MS = 250;
 /**
  * Backstop for a started media session that never produces adapted output. The SDK source owns the
@@ -78,7 +89,7 @@ const SOURCE_ACQUISITION_TIMEOUT = Symbol('source-acquisition-timeout');
  * from a transport that failed.
  */
 function sourceFailure(error: unknown): LiveSessionFailure {
-  if (error instanceof Error && error.name === 'StationBusyError') {
+  if (error instanceof StationBusyError) {
     return 'station-busy';
   }
   return error instanceof LiveStreamStartError && error.stage === 'audio-only' ? 'source-audio-only' : 'source-error';
@@ -263,6 +274,13 @@ export class FfmpegLiveMedia implements LiveMediaAdapter {
     }
 
     let source: LiveStreamConsumer | undefined;
+    /**
+     * Cancels the source acquisition in flight, and is held for exactly as long as one is.
+     *
+     * The station's one media channel is held for the whole of an uncancelled acquisition, so a session that
+     * ends during one cancels it rather than leaving it to the SDK's own wait.
+     */
+    let acquiring: AbortController | undefined;
     let videoProcess: MediaProcess | undefined;
     let audioProcess: MediaProcess | undefined;
     let returnAudioProcess: ReturnAudioProcess | undefined;
@@ -408,6 +426,7 @@ export class FfmpegLiveMedia implements LiveMediaAdapter {
         return;
       }
       stopped = true;
+      acquiring?.abort(new Error('live media session stopped'));
       clearTimeout(rtcpDeadline);
       clearTimeout(initialRtcpGrace);
       clearTimeout(videoStartBackstop);
@@ -416,7 +435,7 @@ export class FfmpegLiveMedia implements LiveMediaAdapter {
       stopProcess(audioProcess);
       if (source) {
         source.stop();
-        transport.onSessionReleased?.();
+        transport.onSessionReleased?.(videoFailed ? 'failed' : 'requested');
       }
       videoPort.close();
       audioPort?.close();
@@ -804,8 +823,10 @@ export class FfmpegLiveMedia implements LiveMediaAdapter {
         const returnAudioReady = startReturnAudio(camera, selection.audio);
         let sourcePromise: Promise<LiveStreamConsumer>;
         let acquisitionDeadline: ReturnType<typeof setTimeout> | undefined;
+        const acquisition = new AbortController();
+        acquiring = acquisition;
         try {
-          sourcePromise = camera.live();
+          sourcePromise = camera.live({ signal: acquisition.signal });
           void sourcePromise.then(
             (lateSource) => {
               if (stopped && source !== lateSource) {
@@ -822,10 +843,12 @@ export class FfmpegLiveMedia implements LiveMediaAdapter {
             }),
           ]);
         } catch (error) {
+          acquisition.abort(new Error('live media source acquisition was cancelled'));
           failVideo(error === SOURCE_ACQUISITION_TIMEOUT ? 'source-acquisition-timeout' : sourceFailure(error));
           throw error === SOURCE_ACQUISITION_TIMEOUT ? new Error('live media source acquisition timed out') : error;
         } finally {
           clearTimeout(acquisitionDeadline);
+          acquiring = undefined;
         }
         if (stopped) {
           source.stop();
@@ -936,12 +959,16 @@ function outputArguments(
  * whole session onto one instant; the constant-rate output then resolves the collision by discarding almost
  * every frame it was given.
  *
- * A negotiated frame rate is a CEILING, not a cadence, so the rate is bounded rather than pinned. Pinning it
- * makes the encoder duplicate frames the source never sent, and each duplicate costs a full encode and a share
- * of the negotiated bit rate for a picture carrying nothing new. Measured on a 1600x1200 doorbell delivering
- * about 15 fps against a 30 fps selection: 264 of 267 emitted frames were duplicates and the adaptation ran at
- * 0.32x real time, so it fell further behind every second and the session died on its backstop with nothing
- * watchable reaching the controller.
+ * A negotiated frame rate is a CEILING, not a cadence, and this output carries the cadence its source arrived
+ * at. A constant-rate output fills every gap in that arrival with a duplicate of the last picture, and each
+ * duplicate costs a full encode and a share of the negotiated bit rate for a frame carrying nothing new; a
+ * source over this transport gaps as its normal case, and an adaptation once behind real time does not recover
+ * inside one session. Measured on the bundled encoder against a 15 fps arrival stalled 1.5 seconds after every
+ * second of media: a constant rate emitted 266 frames of which 146 were duplicates at 0.90x real time, and the
+ * arrival timestamps passed through emitted 120 frames with no duplicate in the same wall time.
+ *
+ * `-fpsmax` states a ceiling for a constant-rate output only and FFmpeg refuses it beside any other frame-rate
+ * mode, so the rate of this output is the rate its source delivers.
  *
  * A negotiated selection states no refresh cadence, so the keyframe interval is plugin policy: `-g` and
  * `-keyint_min` are the negotiated rate doubled and scene-cut detection is off, which is a refresh every two
@@ -985,8 +1012,8 @@ function videoArguments(
     'yuv420p',
     '-vf',
     `scale=${selection.width}:${selection.height}:force_original_aspect_ratio=decrease,pad=${selection.width}:${selection.height}:(ow-iw)/2:(oh-ih)/2`,
-    '-fpsmax',
-    String(selection.fps),
+    '-fps_mode:v',
+    'passthrough',
     '-g',
     String(selection.fps * 2),
     '-keyint_min',

--- a/src/media/live-stream.ts
+++ b/src/media/live-stream.ts
@@ -959,16 +959,20 @@ function outputArguments(
  * whole session onto one instant; the constant-rate output then resolves the collision by discarding almost
  * every frame it was given.
  *
- * A negotiated frame rate is a CEILING, not a cadence, and this output carries the cadence its source arrived
- * at. A constant-rate output fills every gap in that arrival with a duplicate of the last picture, and each
- * duplicate costs a full encode and a share of the negotiated bit rate for a frame carrying nothing new; a
- * source over this transport gaps as its normal case, and an adaptation once behind real time does not recover
- * inside one session. Measured on the bundled encoder against a 15 fps arrival stalled 1.5 seconds after every
- * second of media: a constant rate emitted 266 frames of which 146 were duplicates at 0.90x real time, and the
- * arrival timestamps passed through emitted 120 frames with no duplicate in the same wall time.
+ * A negotiated frame rate is a CEILING, not a cadence, so the rate is bounded rather than pinned. Pinning it
+ * with `-r` makes the encoder interpolate a cadence a bare Annex-B pipe never states, which collapses a session
+ * onto one instant.
  *
- * `-fpsmax` states a ceiling for a constant-rate output only and FFmpeg refuses it beside any other frame-rate
- * mode, so the rate of this output is the rate its source delivers.
+ * The output is constant-rate, which fills a gap in arrival with a duplicate of the last picture rather than
+ * carrying the gap. A duplicate costs a full encode and a share of the negotiated bit rate for a frame carrying
+ * nothing new, and a source over this transport gaps as its normal case: measured on the bundled encoder against
+ * a 15 fps arrival stalled 1.5 seconds after every second of media, a constant rate emitted 266 frames of which
+ * 146 were duplicates, against 120 frames and none when the arrival timestamps were passed through, at the same
+ * 0.90x real time either way. What the duplicates buy is a dense presentation timeline: a controller shown the
+ * gaps instead displays a picture that visibly jumps at every one of them.
+ *
+ * `-fpsmax` states that ceiling for a constant-rate output only, and FFmpeg refuses it beside any other
+ * frame-rate mode, so the two cannot be combined.
  *
  * A negotiated selection states no refresh cadence, so the keyframe interval is plugin policy: `-g` and
  * `-keyint_min` are the negotiated rate doubled and scene-cut detection is off, which is a refresh every two
@@ -1012,8 +1016,8 @@ function videoArguments(
     'yuv420p',
     '-vf',
     `scale=${selection.width}:${selection.height}:force_original_aspect_ratio=decrease,pad=${selection.width}:${selection.height}:(ow-iw)/2:(oh-ih)/2`,
-    '-fps_mode:v',
-    'passthrough',
+    '-fpsmax',
+    String(selection.fps),
     '-g',
     String(selection.fps * 2),
     '-keyint_min',

--- a/src/media/recording.ts
+++ b/src/media/recording.ts
@@ -1,4 +1,5 @@
 import type { FragmentRecordingHandle, MediaFragment } from '@mega-yfue/eufy-sdk';
+import { StationBusyError } from '@mega-yfue/eufy-sdk';
 import { spawn } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 
@@ -29,7 +30,7 @@ import {
  * recording that was simply outranked from looking like a camera that failed.
  */
 function sourceFailure(error: unknown): RecordingFailure {
-  return error instanceof Error && error.name === 'StationBusyError' ? 'station-busy' : 'source-error';
+  return error instanceof StationBusyError ? 'station-busy' : 'source-error';
 }
 
 /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -134,7 +134,7 @@ export function createEufyPlatform(
             accessoryStore,
             (diagnostic, affectedDeviceIds = []) => diagnostics.reportHomeKit(diagnostic, affectedDeviceIds),
             this.cachedAccessories,
-            (trace) => reportHomeKitEvent(diagnosticLog, trace),
+            (trace) => reportHomeKitEvent(diagnosticLog, trace, (serial) => diagnostics.aliasFor(serial)),
             configuredConfig.entityPreferences,
             liveMedia,
             snapshotMedia,

--- a/test/contracts/diagnostic-conditions.test.ts
+++ b/test/contracts/diagnostic-conditions.test.ts
@@ -1411,6 +1411,7 @@ describe('diagnostic conditions', () => {
     reportHomeKitEvent({ debug }, {
       adapter: 'camera.streaming',
       event: 'live-session-released',
+      release: 'requested',
       serial: 'T8000P0000000000',
     } as never);
     reportHomeKitEvent(
@@ -1423,6 +1424,15 @@ describe('diagnostic conditions', () => {
         stage: 'raw-transport' as never,
       },
     );
+    reportHomeKitEvent(
+      { debug },
+      {
+        adapter: 'camera.streaming',
+        event: 'live-session-released',
+        release: 'gave-up' as never,
+      },
+    );
+    reportHomeKitEvent({ debug }, { adapter: 'camera.streaming', event: 'live-session-released' } as never);
 
     expect(debug).toHaveBeenCalledExactlyOnceWith(
       JSON.stringify({
@@ -1430,6 +1440,7 @@ describe('diagnostic conditions', () => {
         level: 'debug',
         adapter: 'camera.streaming',
         event: 'live-session-released',
+        release: 'requested',
       }),
     );
     expect(JSON.stringify(debug.mock.calls)).not.toContain('T8000P0000000000');
@@ -1455,6 +1466,7 @@ describe('diagnostic conditions', () => {
     reportHomeKitEvent(logger, {
       adapter: 'camera.streaming',
       event: 'live-session-released',
+      release: 'failed',
     });
     reportHomeKitEvent(logger, {
       adapter: 'camera.streaming',
@@ -1507,6 +1519,7 @@ describe('diagnostic conditions', () => {
           level: 'debug',
           adapter: 'camera.streaming',
           event: 'live-session-released',
+          release: 'failed',
         }),
       ]),
     );

--- a/test/contracts/guided-diagnostics.test.ts
+++ b/test/contracts/guided-diagnostics.test.ts
@@ -1548,7 +1548,6 @@ describe('guided diagnostics issue handoff', () => {
       const url = complete.issueUrl ?? '';
       const values = [...new URL(url).searchParams.values()].join('\n');
       const resolvable: Readonly<Record<string, string>> = {
-        affectedDevices: 'T8410P0000000000',
         supportCaseId: complete.supportCaseId ?? '',
         ffmpeg: ffmpegPath,
       };
@@ -1641,10 +1640,13 @@ describe('guided diagnostics issue handoff', () => {
 
   /**
    * The devices a reporter names are recorded once, with the session, so nobody has to ask again in the issue.
-   * They do not select what is collected — every log is read either way — and a serial is not operational data,
-   * so the manifest declares the field above that class and the archive is where it travels.
+   * They do not select what is collected — every log is read either way.
+   *
+   * A serial is a device identity, and no evidence class in an archive carries one. The answer therefore travels
+   * as its scope: every device, or how many were named. The serials stay on the host, where the owner's own
+   * session holds them.
    */
-  it('records the devices a reporter names, as evidence rather than as a filter', async () => {
+  it('records the scope a reporter named, without carrying the devices', async () => {
     const root = mkdtempSync(join(tmpdir(), 'homebridge-eufy-affected-'));
     const diagnostics = new GuidedDiagnostics(root, () => Date.parse('2026-09-11T08:00:00.000Z'));
     const named = ['T8410P0000000000', 'T8010P0000000000'];
@@ -1656,10 +1658,13 @@ describe('guided diagnostics issue handoff', () => {
       const { manifest } = await diagnostics.reviewSupportArchive();
       const record = manifest.evidence.find((entry) => entry.evidence === 'reporter-statement');
 
-      expect(authorized.affectedDevices).toEqual(named);
+      expect(authorized.affectedDevices, 'the host keeps the answer it was given').toEqual(named);
       expect(record, 'the statement is an evidence class of its own').toBeDefined();
-      expect(record?.fields).toContainEqual({ field: 'affectedDevices', privacyClass: 'pseudonymous' });
+      expect(record?.fields).toContainEqual({ field: 'affectedDevices', privacyClass: 'operational' });
       expect(manifest.evidence.map((entry) => entry.evidence)).toContain('plugin-log');
+      expect(record?.bytes, 'the statement carries the scope and no serial, which its declared size is what pins').toBe(
+        Buffer.byteLength(`${JSON.stringify({ version: 2, affectedDevices: named.length })}\n`),
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/test/contracts/homekit-reconciler.test.ts
+++ b/test/contracts/homekit-reconciler.test.ts
@@ -495,9 +495,9 @@ describe('HomeKit registry reconciliation', () => {
         adapter: 'contact.sensor',
         event: 'contact-state',
         observation: 'valid',
+        serial,
       },
     ]);
-    expect(JSON.stringify(traces)).not.toContain(serial);
 
     source.publish(
       registryView(
@@ -758,6 +758,7 @@ describe('HomeKit registry reconciliation', () => {
       adapter: 'arming.security-system',
       event: 'security-system-alarm',
       observation: 'valid',
+      serial,
     });
 
     source.publish(registryView(2, new Map(), snapshot()));

--- a/test/contracts/live-media.test.ts
+++ b/test/contracts/live-media.test.ts
@@ -1218,8 +1218,8 @@ describe('live media adaptation', () => {
         'main',
         '-level:v',
         '3.1',
-        '-fps_mode:v',
-        'passthrough',
+        '-fpsmax',
+        '30',
         '-b:v',
         '288k',
         '-payload_type',
@@ -1301,8 +1301,8 @@ describe('live media adaptation', () => {
           'high',
           '-level:v',
           '4.0',
-          '-fps_mode:v',
-          'passthrough',
+          '-fpsmax',
+          '15',
           '-g',
           '30',
           '-b:v',
@@ -1367,7 +1367,7 @@ describe('live media adaptation', () => {
     );
     expect(spawned[1]).toContain('scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2');
     expect(spawned[1]).toEqual(
-      expect.arrayContaining(['-fps_mode:v', 'passthrough', '-g', '30', '-b:v', '144k', '-maxrate', '144k']),
+      expect.arrayContaining(['-fpsmax', '15', '-g', '30', '-b:v', '144k', '-maxrate', '144k']),
     );
     expect(spawned[1]).toEqual(
       expect.arrayContaining([
@@ -1480,9 +1480,7 @@ describe('live media adaptation', () => {
     expect(spawned.map((args) => args[args.indexOf('-f') + 1])).toEqual(['h264', 'hevc']);
     for (const args of spawned) {
       expect(args).toContain('scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2');
-      expect(args).toEqual(
-        expect.arrayContaining(['-fps_mode:v', 'passthrough', '-b:v', '288k', '-payload_type', '99']),
-      );
+      expect(args).toEqual(expect.arrayContaining(['-fpsmax', '30', '-b:v', '288k', '-payload_type', '99']));
       expect(args).not.toContain('-r');
     }
     expect(stream.stop).not.toHaveBeenCalled();
@@ -2103,27 +2101,29 @@ describe('adaptation binary identity', () => {
 });
 
 /**
- * A live adaptation carries the cadence its source arrived at.
+ * A negotiated frame rate is a ceiling, not a cadence, and the output is constant-rate.
  *
- * A constant-rate output fills every gap in arrival with a duplicate of the last picture, and each duplicate
- * costs a full encode and a share of the negotiated bit rate for a frame carrying nothing new. Measured on the
- * bundled encoder against a 15 fps arrival stalled 1.5 seconds after every second of media: a constant rate
- * emitted 266 frames of which 146 were duplicates at 0.90x real time, and the arrival timestamps passed through
- * emitted 120 frames with no duplicate in the same wall time.
+ * Pinning the rate with `-r` makes the encoder interpolate a cadence a bare Annex-B pipe never states, which
+ * collapses a session onto one instant. Bounding it leaves the encoder filling a gap in arrival with a duplicate
+ * of the last picture, which costs a full encode and a share of the negotiated bit rate for a frame carrying
+ * nothing new: measured on the bundled encoder against a 15 fps arrival stalled 1.5 seconds after every second
+ * of media, 266 frames of which 146 were duplicates, against 120 frames and none when the arrival timestamps
+ * were passed through, at the same 0.90x real time either way. What the duplicates buy is a dense presentation
+ * timeline, which is what a controller displays without visibly jumping at every gap.
  *
- * `-fpsmax` states a ceiling for a constant-rate output only and FFmpeg refuses it beside any other frame-rate
- * mode, so neither it nor `-r` may appear on this path.
+ * `-fpsmax` states that ceiling for a constant-rate output only, and FFmpeg refuses it beside any other
+ * frame-rate mode, so the two never appear together.
  */
 describe('live output frame rate', () => {
-  it('passes the source cadence through instead of resampling it to a constant rate', async () => {
+  it('bounds the rate for a constant-rate output, without pinning it', async () => {
     const session = await liveSession();
     await session.start();
     session.stream.video(KEYFRAME);
 
     const args = session.spawned[0]!;
-    expect(args[args.indexOf('-fps_mode:v') + 1]).toBe('passthrough');
+    expect(args[args.indexOf('-fpsmax') + 1]).toBe('30');
     expect(args).not.toContain('-r');
-    expect(args).not.toContain('-fpsmax');
+    expect(args, 'FFmpeg refuses a frame-rate mode beside -fpsmax').not.toContain('-fps_mode:v');
     session.prepared.stop();
   });
 });

--- a/test/contracts/live-media.test.ts
+++ b/test/contracts/live-media.test.ts
@@ -273,7 +273,7 @@ async function talkbackSession(talkback: () => Promise<TalkbackHandle>) {
  * reported outcome. `audio` negotiates the second output so the audio adaptation contracts share this setup.
  */
 async function liveSession(
-  source?: { live(): Promise<LiveStreamConsumer> },
+  source?: { live(options?: { signal?: AbortSignal }): Promise<LiveStreamConsumer> },
   {
     audio,
     stalling,
@@ -451,7 +451,7 @@ describe('live media adaptation', () => {
     expect(session.onVideoFailure).not.toHaveBeenCalled();
     expect(session.outcomes).toEqual([{ outcome: 'streaming' }]);
     session.prepared.stop();
-    expect(session.released).toHaveBeenCalledOnce();
+    expect(session.released).toHaveBeenCalledExactlyOnceWith('requested');
     vi.useRealTimers();
   });
 
@@ -1147,7 +1147,10 @@ describe('live media adaptation', () => {
     ]);
     expect(session.onVideoFailure).toHaveBeenCalledOnce();
     expect(session.stream.stop).toHaveBeenCalledOnce();
-    expect(session.released).toHaveBeenCalledOnce();
+    expect(
+      session.released,
+      'a session that ended itself is not a session a controller closed, and a controller shows the same thing either way',
+    ).toHaveBeenCalledExactlyOnceWith('failed');
     expect(session.children.at(-1)!.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
@@ -1215,8 +1218,8 @@ describe('live media adaptation', () => {
         'main',
         '-level:v',
         '3.1',
-        '-fpsmax',
-        '30',
+        '-fps_mode:v',
+        'passthrough',
         '-b:v',
         '288k',
         '-payload_type',
@@ -1298,8 +1301,8 @@ describe('live media adaptation', () => {
           'high',
           '-level:v',
           '4.0',
-          '-fpsmax',
-          '15',
+          '-fps_mode:v',
+          'passthrough',
           '-g',
           '30',
           '-b:v',
@@ -1364,7 +1367,7 @@ describe('live media adaptation', () => {
     );
     expect(spawned[1]).toContain('scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2');
     expect(spawned[1]).toEqual(
-      expect.arrayContaining(['-fpsmax', '15', '-g', '30', '-b:v', '144k', '-maxrate', '144k']),
+      expect.arrayContaining(['-fps_mode:v', 'passthrough', '-g', '30', '-b:v', '144k', '-maxrate', '144k']),
     );
     expect(spawned[1]).toEqual(
       expect.arrayContaining([
@@ -1477,7 +1480,9 @@ describe('live media adaptation', () => {
     expect(spawned.map((args) => args[args.indexOf('-f') + 1])).toEqual(['h264', 'hevc']);
     for (const args of spawned) {
       expect(args).toContain('scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2');
-      expect(args).toEqual(expect.arrayContaining(['-fpsmax', '30', '-b:v', '288k', '-payload_type', '99']));
+      expect(args).toEqual(
+        expect.arrayContaining(['-fps_mode:v', 'passthrough', '-b:v', '288k', '-payload_type', '99']),
+      );
       expect(args).not.toContain('-r');
     }
     expect(stream.stop).not.toHaveBeenCalled();
@@ -1684,15 +1689,32 @@ describe('live media adaptation', () => {
 
   it('bounds stalled source acquisition and no-RTCP sessions', async () => {
     vi.useFakeTimers();
-    const stalled = await liveSession({ live: () => new Promise<LiveStreamHandle>(() => undefined) });
+    let acquisitionSignal: AbortSignal | undefined;
+    const stalled = await liveSession({
+      live: (options) => {
+        acquisitionSignal = options?.signal;
+        return new Promise<LiveStreamHandle>(() => undefined);
+      },
+    });
     const start = expect(stalled.start()).rejects.toThrow('source acquisition timed out');
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(stalled.outcomes, 'the SDK owns waits longer than this, so the bound sits above reaching a station').toEqual(
+      [],
+    );
+    expect(acquisitionSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
     await start;
 
     expect(stalled.onVideoFailure).toHaveBeenCalledOnce();
     expect(stalled.outcomes).toEqual([
       { outcome: 'failed', reason: 'source-acquisition-timeout', stage: 'sdk-source-acquisition' },
     ]);
+    expect(
+      acquisitionSignal?.aborted,
+      'an abandoned acquisition holds the station channel until the SDK stops waiting for it too',
+    ).toBe(true);
 
     const noRtcp = await liveSession();
     await noRtcp.start();
@@ -2081,25 +2103,27 @@ describe('adaptation binary identity', () => {
 });
 
 /**
- * A negotiated frame rate is a ceiling, not a cadence.
+ * A live adaptation carries the cadence its source arrived at.
  *
- * Pinning it with `-r` makes the encoder duplicate frames the source never sent, and each duplicate costs a
- * full encode and a share of the negotiated bit rate for a picture carrying nothing new. Measured on a
- * 1600x1200 doorbell delivering about 15 fps against a 30 fps selection: 264 of 267 emitted frames were
- * duplicates, and the adaptation ran at 0.32x real time — so it fell further behind every second and the
- * session died on its 30 s backstop with nothing watchable ever reaching the controller.
+ * A constant-rate output fills every gap in arrival with a duplicate of the last picture, and each duplicate
+ * costs a full encode and a share of the negotiated bit rate for a frame carrying nothing new. Measured on the
+ * bundled encoder against a 15 fps arrival stalled 1.5 seconds after every second of media: a constant rate
+ * emitted 266 frames of which 146 were duplicates at 0.90x real time, and the arrival timestamps passed through
+ * emitted 120 frames with no duplicate in the same wall time.
  *
- * The recording path already states this rule and bounds the rate; this is the same rule on the live path.
+ * `-fpsmax` states a ceiling for a constant-rate output only and FFmpeg refuses it beside any other frame-rate
+ * mode, so neither it nor `-r` may appear on this path.
  */
 describe('live output frame rate', () => {
-  it('bounds the rate instead of pinning it, so a slower source is not padded with duplicates', async () => {
+  it('passes the source cadence through instead of resampling it to a constant rate', async () => {
     const session = await liveSession();
     await session.start();
     session.stream.video(KEYFRAME);
 
     const args = session.spawned[0]!;
-    expect(args[args.indexOf('-fpsmax') + 1]).toBe('30');
+    expect(args[args.indexOf('-fps_mode:v') + 1]).toBe('passthrough');
     expect(args).not.toContain('-r');
+    expect(args).not.toContain('-fpsmax');
     session.prepared.stop();
   });
 });

--- a/test/contracts/live-observability.test.ts
+++ b/test/contracts/live-observability.test.ts
@@ -13,6 +13,78 @@ import {
 } from '../../src/diagnostics.js';
 
 /**
+ * Which camera a media record is about.
+ *
+ * One adapter serves every camera of a household, so a record naming only the adapter states that something
+ * happened to one of them. The alias is the one the conditions about that accessory already carry, which is what
+ * makes two records about one camera readable as one camera. The identity itself is never retained.
+ */
+describe('the accessory a media record names', () => {
+  it('carries the support-case alias for its device and never the device', () => {
+    const debug = vi.fn();
+    const alias = 'accessory-1a3abd19-1355-416e-a698-ed95767be1cb';
+    const serial = 'T8172P10254111FB';
+    const aliasFor = (identity: string) => (identity === serial ? alias : undefined);
+
+    reportHomeKitEvent({ debug }, { adapter: 'camera.streaming', event: 'live-session-streaming', serial }, aliasFor);
+    reportHomeKitEvent(
+      { debug },
+      {
+        adapter: 'camera.streaming',
+        event: 'live-session-failed',
+        outcome: 'failed',
+        reason: 'source-acquisition-timeout',
+        stage: 'sdk-source-acquisition',
+        serial,
+      },
+      aliasFor,
+    );
+    reportHomeKitEvent(
+      { debug },
+      {
+        adapter: 'camera.streaming',
+        event: 'live-video-selected',
+        operation: 'start',
+        profile: 'high',
+        level: '4.0',
+        width: 1280,
+        height: 720,
+        fps: 30,
+        mtu: 1378,
+        addressVersion: 'ipv4',
+        serial,
+      },
+      aliasFor,
+    );
+    reportHomeKitEvent(
+      { debug },
+      { adapter: 'motion.sensor', event: 'motion-detection', observation: 'valid', serial },
+      aliasFor,
+    );
+
+    expect(records(debug).map((record) => record.accessory)).toEqual([alias, alias, alias, alias]);
+    expect(JSON.stringify(records(debug))).not.toContain(serial);
+  });
+
+  it('carries no accessory where the caller resolves no alias, rather than an identity', () => {
+    const debug = vi.fn();
+    const serial = 'T8172P10254111FB';
+
+    reportHomeKitEvent({ debug }, { adapter: 'camera.streaming', event: 'live-session-streaming', serial });
+    reportHomeKitEvent(
+      { debug },
+      { adapter: 'camera.streaming', event: 'live-session-released', serial },
+      () => undefined,
+    );
+
+    for (const record of records(debug)) {
+      expect(record.accessory).toBeUndefined();
+    }
+    expect(JSON.stringify(records(debug))).not.toContain(serial);
+  });
+});
+
+/**
  * The two facts a stream nobody can see is diagnosed from.
  *
  * Everything before them was already traced: HomeKit's selection, the station's key, the warm-up window, the

--- a/test/contracts/recording-media.test.ts
+++ b/test/contracts/recording-media.test.ts
@@ -3,6 +3,7 @@ import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { FragmentRecordingHandle, MediaFragment, StreamBudgetNotice } from '@mega-yfue/eufy-sdk';
+import { StationBusyError } from '@mega-yfue/eufy-sdk';
 
 import type {
   AdaptationNotice,
@@ -653,15 +654,24 @@ describe('recording media adaptation', () => {
    * A base serves one of its cameras at a time, and the SDK refuses a second rather than degrading both. A
    * recording that was simply outranked is not a camera that failed, and naming the two apart is what lets an
    * operator read the difference in a log.
+   *
+   * The refusal is recognised by the SDK's exported type, so an error that merely calls itself one is a source
+   * failure: a name is a string any thrower can write, and this distinction decides what an operator is told.
    */
   it('names a station serving another camera apart from a source that failed', async () => {
     const session = recordingSession();
     await settle();
-    const busy = new Error('the station is already serving channel 0 to a viewer');
-    busy.name = 'StationBusyError';
-    session.source.fail(busy);
+    session.source.fail(new StationBusyError(0));
     await session.consumed.iteration;
     expect(session.outcomes).toEqual([{ outcome: 'failed', reason: 'station-busy' }]);
+
+    const impostor = recordingSession();
+    await settle();
+    const named = new Error('the station is already serving channel 0 to a viewer');
+    named.name = 'StationBusyError';
+    impostor.source.fail(named);
+    await impostor.consumed.iteration;
+    expect(impostor.outcomes).toEqual([{ outcome: 'failed', reason: 'source-error' }]);
   });
 
   /**


### PR DESCRIPTION
Fixes one of the two faults behind #1089, and the five reasons its archives could not settle it. **Verified on a live 8-camera fleet**, which also cost the second fault its place in this PR — see *Withdrawn* below.

## Fault A — a HomeBase-attached camera never reached the wire

19 of 19 failures in the reporter's archive landed at **10.001 ± 0.001 s**: `SOURCE_ACQUISITION_DEADLINE_MS`, not a network variable. Across both archives (8 min, ~14 cameras) every SDK `media-command` carried `topology: "own"` — the two standalone cameras. **Not one media command, and not one `warming` phase, for any of the 12 S1 cameras.**

`camera.live()` → `sharedLiveSourceFor` → `resolveSession`, whose connect wait is `CONNECT_WAIT_MS = 20_000` and which emits no trace at all. The plugin abandoned at 10 s, and the abandoned acquisition kept holding the station's one media channel while the controller's retry (9.2 s cadence) opened another against it — so no attempt was ever left alone for the wait it needed.

**What the archives do and do not say about that S1.** Nothing in either archive is attributable to it: the only stations named anywhere are `station-40` and `station-49`, both `topology: "own"`, his two standalone cameras. The session lifecycle events carry no station identity at all —

```
('session-connecting', ('event', 'subsystem'))
('connection-opened',  ('event', 'subsystem'))
('operation-failed',   ('details', 'event', 'subsystem'))
```

— so his 12 `session-connecting` and 13 `connection-opened` records cannot be assigned to the S1 or to a standalone station. That the S1's media path produced nothing is a fact; that it never finished connecting is an inference from absent traces, and a line that failed to appear is not evidence that nothing happened.

- The bound now sits above what reaching a station costs and below both `SOURCE_START_BACKSTOP_MS` and `UNACCOUNTED_REQUEST_MS`, so the acquisition is what its expiry reports.
- Expiry **cancels** through the `signal` that both `SharedLiveOpts` and this plugin's own `LiveMediaSource.live()` already declared and the call site never passed. A session stopped mid-acquisition cancels too.

`level2-*` trace phases were **already** allowlisted and appear nowhere in either archive, which is what places the hang in the connect wait rather than in the level-2 negotiation. On a healthy fleet `level2-wait` → `level2-ready` takes **352 ms**.

**Measured effect on a live fleet** (`live-video-selected` → `live-session-streaming`, 10 sessions):

```
0.56  0.82  0.85  0.93  0.94  0.99  1.22  2.09  2.42  4.69   median ~0.97 s
```

Time to picture is unchanged. What the wider bound changes is the *failure* path, deliberately:

```
FAILED source-audio-only after 20.31s    <- the SDK's own verdict, at its 20 s warm-up deadline
```

Before, the 10 s bound cut in first and reported `source-acquisition-timeout` — a plugin timeout standing in for a camera that was sending audio and no video. The reason is now true, and arrives later. A camera that is merely slow to reach now streams instead of never starting.

## What the archives could not say

1. **No accessory identity on media traces.** 19 failed and 6 streaming sessions with no way to attribute any of them; I had to infer per-camera attribution from station topology. Records now carry the support-case alias the conditions already carry, and the serial never reaches the record. *Live: three cameras separable in one window.*
2. **`live-session-released` carried no reason.** A controller stops showing a picture whether it closed the view or the session failed. It now states `requested` or `failed`. *Live: both observed, every `failed` paired with a `live-session-failed`, every `requested` standing alone.*
3. **Every SDK error reached the archive as `Error`.** `StationBusyError` is publicly exported, yet was sniffed by `.name` in two places and dropped by the allowlist. Now `instanceof`, allowlisted, one shared `SDK_ERROR_TYPES`. A faked name is now a source failure, which a new contract pins.
4. **The archive carried a raw device serial.** `reporter-statement` held the reporter's serials declared `pseudonymous`; `AGENTS.md` lists serials as sensitive. It now carries the scope — `all`, or how many were named.
5. **`scripts/decrypt-diagnostics.mjs` could not open either archive.** `reporter-statement` was missing from `EVIDENCE_FILES`, so every archive carrying one was rejected as `Invalid or duplicate manifest evidence`. Verified against the reporter's real archive: extracts 7 files, and archives predating the change still validate.

## Withdrawn from this PR — the live-video frame-rate change

This PR first replaced `-fpsmax` with `-fps_mode:v passthrough`, on the reading that CFR duplication (dup 18–205 per session, `speed` 0.53–0.92x in the reporter's archive) was starving the adaptation. The live fleet refuted the reasoning:

| args | frames | dup | speed |
|---|---|---|---|
| `-fpsmax 30` | 266 | 146 | **0.90x** |
| `-fps_mode:v passthrough` | 120 | 0 | **0.90x** |

Same speed. Passthrough halves the encoder work and **buys nothing** on the metric the argument rested on. Worse, on the live fleet it was visible: a camera's own on-screen clock jumped at every source gap, because the duplicates were what kept the presentation timeline dense.

The constant rate is therefore kept and the JSDoc and contract now state *why*, so the cheaper output is not mistaken for a free improvement later. Fault B needs a CPU-bound reproduction before anything is claimed about it, and gets its own issue.

## Verified

- `npm run verify` green against the committed SDK pin **0.1.2**: prettier, ECS guard, `tsc`, **877 tests / 50 files**. (0.1.2 keeps `CONNECT_WAIT_MS = 2e4` and `LEVEL2_GRACE_MS = 25e3`, so every derivation above holds.)
- Live host per `AGENTS.md`: built, restarted, and order proven (`ActiveEnterTimestamp` 20:27:39 > newest `dist` 20:27:34), the loaded `dist` grepped for each symbol, Homebridge debug output on before measuring.
- FFmpeg behaviour measured on the bundled binary, not inferred: CFR duplication reproduced with an arrival-paced pipe, and `-fpsmax` + non-CFR confirmed rejected by FFmpeg 8 outright.

## Inconclusive, and reported as such

- **Fault A's curative claim.** The test fleet's stations reach `level2-ready` in 352 ms; the reporter's S1 never finishes the connect wait. This PR proves the bound does not break a healthy attached path (`topology: attached` ×4, `level2-ready` ×3, no `level2-absent`, zero acquisition expiries) — not that it cures their 12 cameras.
- **The `/proc` argv observation** was not captured: the watcher's stdout was fully buffered to a file and the session ended first. The claim rests on the grepped `dist` plus a proven restart order, which is weaker.

## Deferred — needs the SDK

- **The connect wait has no trace.** `resolveSession` can wait 20 s (and `awaitLevel2Key` 25 s, twice) with nothing recorded. A `session-connect` phase would have answered #1089 in one round.
- **No typed reason for a station that cannot be reached**, so the plugin cannot fail fast to a placeholder.
- **`SharedLiveOpts` exposes no connect or level-2 bound**, so the plugin can only hardcode a number above an SDK internal it cannot read.
- **Session lifecycle events carry no station identity**, which is what made the question "did that S1 react at all?" unanswerable from two archives. `session-connecting`, `connection-opened`, `session-idle` and `operation-failed` are classified from SDK log messages whose only identifier is a serial the plugin must not retain, so the plugin cannot attribute them. Emitting them as traces carrying the SDK's own `station-N` handle, as the media traces already do, would make every session event attributable. This is the most expensive of the gaps listed here.
