### PR TITLE
feat(diagnostics): state which Homebridge an archive came from

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -176,7 +176,7 @@ const DIAGNOSTICS_DIRECTORY = 'diagnostics';
 const GUIDED_SESSION_FILE = 'session.json';
 const REPRODUCTION_MARKERS_FILE = 'reproduction-markers.jsonl';
 const UI_EVENTS_FILE = 'ui-events.jsonl';
-const FFMPEG_ENVIRONMENT_FILE = 'ffmpeg.json';
+const HOST_ENVIRONMENT_FILE = 'host.json';
 /** How much of an FFmpeg path or version banner is kept, which is more than either needs. */
 const MAX_FFMPEG_IDENTITY_LENGTH = 256;
 const DEBUG_AUTHORIZATION_MS = 72 * 60 * 60 * 1_000;
@@ -568,54 +568,92 @@ interface PersistedFfmpegEnvironment {
   version?: string;
 }
 
-function ffmpegEnvironmentPath(storageRoot: string): string {
-  return join(storageRoot, DIAGNOSTICS_DIRECTORY, FFMPEG_ENVIRONMENT_FILE);
+function hostEnvironmentPath(storageRoot: string): string {
+  return join(storageRoot, DIAGNOSTICS_DIRECTORY, HOST_ENVIRONMENT_FILE);
+}
+
+/** The longest host version string retained, which bounds a value this plugin does not choose. */
+const MAX_HOST_VERSION_LENGTH = 64;
+
+/**
+ * What the running host is, as only the process that has Homebridge's API can state it.
+ *
+ * The Homebridge version decides whether this plugin can run at all: V5 requires Homebridge 2, and a V1 host
+ * loads it and then fails in ways indistinguishable from a media fault. It is the host's own public version,
+ * so it carries no device or account material.
+ */
+interface PersistedHostEnvironment {
+  readonly homebridge?: string;
+  readonly ffmpeg?: PersistedFfmpegEnvironment;
 }
 
 /**
- * Records which FFmpeg this run resolved, so a support archive states the build a failure came from.
+ * Records what this run is hosted by, so a support archive states the host a failure came from.
  *
- * It is persisted rather than held in memory because the process that resolves it is not the one that
- * assembles an archive, and it is rewritten on every start so a path or binary that changed between runs
- * cannot be reported as the one in use. A write that fails is dropped: the archive then declares the
- * environment without an FFmpeg identity, which is honest, whereas failing startup over a diagnostic file
- * would cost the user their cameras.
+ * It is persisted rather than held in memory because the process that knows these facts is not the one that
+ * assembles an archive, and it is rewritten on every start so a host or binary that changed between runs
+ * cannot be reported as the one in use. Each call replaces the record whole, so a caller states everything it
+ * knows rather than accumulating into a file two writers would race for.
+ *
+ * A write that fails is dropped: the archive then declares the environment without these facts, which is
+ * honest, whereas failing startup over a diagnostic file would cost the user their cameras.
  */
-export function recordFfmpegEnvironment(storageRoot: string, ffmpeg: PersistedFfmpegEnvironment): void {
+export function recordHostEnvironment(storageRoot: string, host: PersistedHostEnvironment): void {
   try {
-    const path = ffmpegEnvironmentPath(storageRoot);
+    const path = hostEnvironmentPath(storageRoot);
     mkdirSync(dirname(path), { mode: 0o700, recursive: true });
-    writeFileSync(path, `${JSON.stringify({ version: 1, ffmpeg })}\n`, { mode: 0o600 });
+    writeFileSync(path, `${JSON.stringify({ version: 2, ...host })}\n`, { mode: 0o600 });
   } catch {}
 }
 
 /**
- * Reads the recorded adaptation binary, refusing a record whose own fields do not narrow.
+ * Reads what this run is hosted by, keeping each fact that narrows and dropping each that does not.
+ *
+ * The facts are independent, so a malformed binary identity does not withhold a host version, and a record
+ * stating neither is no record at all.
+ */
+function readHostEnvironment(storageRoot: string): PersistedHostEnvironment | undefined {
+  try {
+    const candidate = JSON.parse(readFileSync(hostEnvironmentPath(storageRoot), 'utf8')) as Record<string, unknown>;
+    if (candidate.version !== 2) {
+      return undefined;
+    }
+    const homebridge =
+      typeof candidate.homebridge === 'string' ? boundedText(candidate.homebridge, MAX_HOST_VERSION_LENGTH) : undefined;
+    const ffmpeg = readFfmpegIdentity(candidate.ffmpeg);
+    if (homebridge === undefined && ffmpeg === undefined) {
+      return undefined;
+    }
+    return {
+      ...(homebridge === undefined ? {} : { homebridge }),
+      ...(ffmpeg === undefined ? {} : { ffmpeg }),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The recorded adaptation binary, or nothing where the record's own fields do not narrow.
  *
  * The path and the banner are kept as written rather than pattern-replaced, because naming the binary is the
  * entire purpose of the record and a redacted one answers nothing. Neither is device or account material: the
  * path is this plugin's own setting or the binary it ships, and the banner is that build's public identity.
  */
-function readFfmpegEnvironment(storageRoot: string): PersistedFfmpegEnvironment | undefined {
-  try {
-    const candidate = JSON.parse(readFileSync(ffmpegEnvironmentPath(storageRoot), 'utf8')) as Record<string, unknown>;
-    const ffmpeg = candidate.ffmpeg;
-    if (candidate.version !== 1 || !ffmpeg || typeof ffmpeg !== 'object' || Array.isArray(ffmpeg)) {
-      return undefined;
-    }
-    const recorded = ffmpeg as Record<string, unknown>;
-    if (typeof recorded.path !== 'string' || (recorded.source !== 'bundled' && recorded.source !== 'configured')) {
-      return undefined;
-    }
-    const path = boundedText(recorded.path, MAX_FFMPEG_IDENTITY_LENGTH);
-    const version =
-      typeof recorded.version === 'string' ? boundedText(recorded.version, MAX_FFMPEG_IDENTITY_LENGTH) : undefined;
-    return path === undefined
-      ? undefined
-      : { path, source: recorded.source, ...(version === undefined ? {} : { version }) };
-  } catch {
+function readFfmpegIdentity(value: unknown): PersistedFfmpegEnvironment | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
   }
+  const recorded = value as Record<string, unknown>;
+  if (recorded.source !== 'bundled' && recorded.source !== 'configured') {
+    return undefined;
+  }
+  const path = typeof recorded.path === 'string' ? boundedText(recorded.path, MAX_FFMPEG_IDENTITY_LENGTH) : undefined;
+  const version =
+    typeof recorded.version === 'string' ? boundedText(recorded.version, MAX_FFMPEG_IDENTITY_LENGTH) : undefined;
+  return path === undefined
+    ? undefined
+    : { path, source: recorded.source, ...(version === undefined ? {} : { version }) };
 }
 
 /**
@@ -908,7 +946,7 @@ export class GuidedDiagnostics {
   }
 
   private async collectSupportEvidence(session: PersistedDiagnosticsSession): Promise<SupportArchiveEvidence[]> {
-    const ffmpeg = readFfmpegEnvironment(this.storageRoot);
+    const host = readHostEnvironment(this.storageRoot);
     const evidence: SupportArchiveEvidence[] = [
       ...(session.affectedDevices === undefined
         ? []
@@ -933,18 +971,22 @@ export class GuidedDiagnostics {
         evidence: 'environment',
         privacyClass: 'operational',
         contentType: 'application/json',
-        content: `${JSON.stringify({ version: 2, plugin: PLUGIN_VERSION, sdk: SDK_VERSION, node: process.version, platform: process.platform, arch: process.arch, ...(ffmpeg ? { ffmpeg } : {}) })}\n`,
+        content: `${JSON.stringify({ version: 3, plugin: PLUGIN_VERSION, sdk: SDK_VERSION, node: process.version, ...(host?.homebridge ? { homebridge: host.homebridge } : {}), platform: process.platform, arch: process.arch, ...(host?.ffmpeg ? { ffmpeg: host.ffmpeg } : {}) })}\n`,
         /**
          * The record is operational and one field is classified above it: a resolved FFmpeg path is an
          * environment fact, but it can carry the home directory of the account Homebridge runs as, so it is
          * declared as diagnostic rather than presented alongside the host's own architecture.
+         *
+         * The Homebridge version is operational and load-bearing: this plugin requires Homebridge 2, and a
+         * host that predates it loads the plugin and then fails in ways a media fault cannot be told from.
          */
         fields: [
           ...['version', 'plugin', 'sdk', 'node', 'platform', 'arch'].map((field) => ({
             field,
             privacyClass: 'operational' as const,
           })),
-          ...(ffmpeg ? [{ field: 'ffmpeg', privacyClass: 'diagnostic' as const }] : []),
+          ...(host?.homebridge ? [{ field: 'homebridge', privacyClass: 'operational' as const }] : []),
+          ...(host?.ffmpeg ? [{ field: 'ffmpeg', privacyClass: 'diagnostic' as const }] : []),
         ],
       },
     ];

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -4,7 +4,7 @@ import { ffmpegPathSource, parseConfig } from './configuration.js';
 import {
   createDiagnosticLogger,
   DiagnosticConditions,
-  recordFfmpegEnvironment,
+  recordHostEnvironment,
   reportAdaptationNotice,
   reportDiscardedV4Settings,
   reportHomeKitEvent,
@@ -36,6 +36,8 @@ export interface PlatformSignalTarget {
 
 export interface PlatformApi {
   on(event: PlatformLifecycleEvent, listener: () => void): void;
+  /** The host's own semver version, which decides whether this plugin can run on it at all. */
+  serverVersion?: string;
   user?: { storagePath(): string };
   hap?: HAP;
   platformAccessory?: API['platformAccessory'];
@@ -122,10 +124,14 @@ export function createEufyPlatform(
       });
       api.on('didFinishLaunching', () => {
         const ffmpegPath = configuredConfig.ffmpegPath;
-        if (ffmpegPath && storageRoot) {
-          void resolveFfmpegIdentity(ffmpegPath, ffmpegPathSource(ffmpegPath)).then((identity) =>
-            recordFfmpegEnvironment(storageRoot, identity),
-          );
+        if (storageRoot) {
+          const homebridge = typeof api.serverVersion === 'string' ? { homebridge: api.serverVersion } : {};
+          recordHostEnvironment(storageRoot, homebridge);
+          if (ffmpegPath) {
+            void resolveFfmpegIdentity(ffmpegPath, ffmpegPathSource(ffmpegPath)).then((ffmpeg) =>
+              recordHostEnvironment(storageRoot, { ...homebridge, ffmpeg }),
+            );
+          }
         }
         const accessoryStore = createAccessoryStore(api);
         if (accessoryStore) {

--- a/test/contracts/guided-diagnostics.test.ts
+++ b/test/contracts/guided-diagnostics.test.ts
@@ -22,7 +22,7 @@ import {
   createDiagnosticLogger,
   type DiagnosticsProfile,
   GuidedDiagnostics,
-  recordFfmpegEnvironment,
+  recordHostEnvironment,
   reportAdaptationNotice,
   reportHomeKitEvent,
   reportInvalidSnapshotCache,
@@ -793,7 +793,7 @@ describe('guided diagnostics session', () => {
         JSON.parse(payload.evidence[0]!.content),
         'an archive names the builds that produced it, so a reader can see a fault is already fixed',
       ).toMatchObject({
-        version: 2,
+        version: 3,
         plugin: ownManifest.version,
         sdk: installedSdk.version,
       });
@@ -1299,17 +1299,24 @@ describe('guided diagnostics session', () => {
    * without the resolved binary in the record an adaptation failure can be attributed to FFmpeg in general
    * and to nothing more precise. A path that names nothing runnable answers with no version at all, which is
    * what tells a missing or wrong `ffmpegPath` apart from an encoder the build does not have.
+   *
+   * The host's own version sits beside it, because this plugin requires Homebridge 2 and a host that predates
+   * it loads the plugin and then fails in ways a media fault cannot be told from. The two facts are
+   * independent: a malformed binary identity does not withhold the host version.
    */
-  it('reports the resolved FFmpeg identity as environment evidence and declares its privacy class', async () => {
+  it('reports the host and the resolved FFmpeg identity as environment evidence, each declared', async () => {
     const root = mkdtempSync(join(tmpdir(), 'homebridge-eufy-guided-'));
     let now = Date.parse('2026-08-17T08:00:00.000Z');
     const diagnostics = new GuidedDiagnostics(root, () => now);
 
     try {
-      recordFfmpegEnvironment(root, {
-        path: '/synthetic/bin/ffmpeg',
-        source: 'configured',
-        version: 'ffmpeg version 8.0 Copyright (c) 2000-2026 the FFmpeg developers',
+      recordHostEnvironment(root, {
+        homebridge: '2.4.0',
+        ffmpeg: {
+          path: '/synthetic/bin/ffmpeg',
+          source: 'configured',
+          version: 'ffmpeg version 8.0 Copyright (c) 2000-2026 the FFmpeg developers',
+        },
       });
       await diagnostics.authorize('live-media', 'now');
       await diagnostics.startReproduction();
@@ -1328,22 +1335,35 @@ describe('guided diagnostics session', () => {
           { field: 'node', privacyClass: 'operational' },
           { field: 'platform', privacyClass: 'operational' },
           { field: 'arch', privacyClass: 'operational' },
+          { field: 'homebridge', privacyClass: 'operational' },
           { field: 'ffmpeg', privacyClass: 'diagnostic' },
         ],
       });
-      expect(statSync(join(root, 'diagnostics', 'ffmpeg.json')).mode & 0o777).toBe(0o600);
+      expect(statSync(join(root, 'diagnostics', 'host.json')).mode & 0o777).toBe(0o600);
 
-      recordFfmpegEnvironment(root, { path: '/synthetic/bin/ffmpeg', source: 'bundled' });
+      recordHostEnvironment(root, {
+        homebridge: '2.4.0',
+        ffmpeg: { path: '/synthetic/bin/ffmpeg', source: 'bundled' },
+      });
       const rerecorded = (await diagnostics.reviewSupportArchive()).manifest.evidence[0]!;
       expect(
         rerecorded.fields,
         'a binary that answered no version banner is reported without one rather than with a guess',
-      ).toHaveLength(7);
+      ).toHaveLength(8);
 
-      writeFileSync(join(root, 'diagnostics', 'ffmpeg.json'), '{"version":1,"ffmpeg":{"source":"invented"}}\n');
+      writeFileSync(
+        join(root, 'diagnostics', 'host.json'),
+        '{"version":2,"homebridge":"2.4.0","ffmpeg":{"source":"invented"}}\n',
+      );
       expect(
         (await diagnostics.reviewSupportArchive()).manifest.evidence[0]!.fields,
-        'a record whose own fields do not narrow is dropped rather than partly reported',
+        'a binary identity that does not narrow is dropped without withholding the host version',
+      ).toHaveLength(7);
+
+      writeFileSync(join(root, 'diagnostics', 'host.json'), '{"version":2,"ffmpeg":{"source":"invented"}}\n');
+      expect(
+        (await diagnostics.reviewSupportArchive()).manifest.evidence[0]!.fields,
+        'a record stating neither fact is no record at all',
       ).toHaveLength(6);
     } finally {
       rmSync(root, { force: true, recursive: true });
@@ -1540,7 +1560,7 @@ describe('guided diagnostics issue handoff', () => {
     const ffmpegPath = '/home/synthetic-operator/.local/bin/ffmpeg';
 
     try {
-      recordFfmpegEnvironment(root, { path: ffmpegPath, source: 'configured' });
+      recordHostEnvironment(root, { homebridge: '2.4.0', ffmpeg: { path: ffmpegPath, source: 'configured' } });
       await diagnostics.authorize('live-media', 'now', ['T8410P0000000000']);
       await diagnostics.startReproduction();
       const complete = await diagnostics.endReproduction();


### PR DESCRIPTION
## Why

This plugin requires **Homebridge 2**. A host that predates it loads the plugin and then fails in ways a media fault cannot be told from.

The archive states the plugin, the SDK, Node, the platform, the architecture and the FFmpeg build — and not the one version that decides whether any of it can work. So it has to be asked for in the issue instead, where it is regularly left blank: #1089 carries no Homebridge version after two rounds of asking.

## How

Only the process holding Homebridge's `API` can state it, and that is not the process that assembles an archive. That is the same reason the FFmpeg identity is persisted, so this travels the same way rather than through a second file with its own lifetime. The record describes the host rather than the binary alone:

- written on **every start**, whether or not an `ffmpegPath` is configured, because a default install configures none and would otherwise carry no host version;
- each fact **narrows independently**, so a malformed binary identity does not withhold the host version, and a record stating neither fact is no record;
- `api.serverVersion` is optional on the plugin's own minimal `PlatformApi`, like every other member of it, so a host that does not state its version is reported without one rather than with a guess.

`environment` evidence goes to version 3, with `homebridge` declared `operational` — it is the host's own public version and carries no device or account material.

## Verified

- `npm run verify` green: prettier, ECS guard, `tsc`, **877 tests / 50 files**.
- **End to end against the reader**, not only through the contract suite: an archive generated by this build and opened with `scripts/decrypt-diagnostics.mjs` yields

  ```json
  {"version":3,"plugin":"5.0.0-beta.0","sdk":"0.1.2","node":"v24.19.0","homebridge":"2.4.0","platform":"linux","arch":"x64","ffmpeg":{...}}
  ```

- The reader requires no change: it validates a field's name and privacy class rather than an allowlist of names, so a new operational field passes. Established by running it.
- The contract pins all three narrowing cases: both facts present, a binary identity that does not narrow, and a record stating neither.